### PR TITLE
feat: 어드민 지원서 상세보기 모달창 구현

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -135,7 +135,7 @@ const Header = () => {
         </HomeWrapper>
         <MenuWrapper>
           <MenuListWrapper>
-            <MenuList href="" $isApplyPage={isApplyPage}>
+            <MenuList href="/project" $isApplyPage={isApplyPage}>
               프로젝트
             </MenuList>
             <MenuList href="/leader" $isApplyPage={isApplyPage}>

--- a/src/components/admin/AdminModal.jsx
+++ b/src/components/admin/AdminModal.jsx
@@ -1,0 +1,267 @@
+import styled from "styled-components";
+import FileClose from "../../assets/icons/FileClose.svg";
+
+const AdminModal = ({ isOpen, closeModal, application }) => {
+  if (!isOpen) return null;
+
+  const handleOverlayClick = (e) => {
+    // e.target이 ModalContainer일 때만 닫히도록
+    if (e.target === e.currentTarget) {
+      closeModal();
+    }
+  };
+
+  return (
+    <ModalContainer onClick={handleOverlayClick}>
+      <ModalContent>
+        <CloseBtn onClick={closeModal}>
+          <img src={FileClose} />
+        </CloseBtn>
+        {application && (
+          <ApplicationContent>
+            <SectionTitle>인적 사항</SectionTitle>
+            <PersonalInfoSection>
+              <Section>
+                <InfoGrid>
+                  <InfoItem>
+                    <Label>이름 :</Label>
+                    <Value>{application.name}</Value>
+                  </InfoItem>
+                  <InfoItem>
+                    <Label>생년월일 :</Label>
+                    <Value>{application.birth}</Value>
+                  </InfoItem>
+                  <InfoItem>
+                    <Label>성별 :</Label>
+                    <Value>{application.gender === "MALE" ? "남" : "여"}</Value>
+                  </InfoItem>
+                  <InfoItem>
+                    <Label>닉네임 :</Label>
+                    <Value>{application.nickName}</Value>
+                  </InfoItem>
+                  <InfoItem>
+                    <Label>이메일 :</Label>
+                    <Value>{application.email}</Value>
+                  </InfoItem>
+                </InfoGrid>
+              </Section>
+
+              <Section>
+                <InfoGrid>
+                  <InfoItem>
+                    <Label>학번 :</Label>
+                    <Value>{application.studentId}</Value>
+                  </InfoItem>
+                  <InfoItem>
+                    <Label>학과 :</Label>
+                    <Value>{application.major}</Value>
+                  </InfoItem>
+                  <InfoItem>
+                    <Label>재학 여부 :</Label>
+                    <Value>
+                      {application.gradeStatus === "IN_SCHOOL"
+                        ? "재학"
+                        : application.gradeStatus === "STOP_SCHOOL"
+                        ? "휴학"
+                        : application.gradeStatus === "GRADUATE"
+                        ? "졸업"
+                        : application.gradeStatus}
+                    </Value>
+                  </InfoItem>
+                  <InfoItem>
+                    <Label>학년 :</Label>
+                    <Value>
+                      {application.grade === "FIRST"
+                        ? "1학년"
+                        : application.grade === "SECOND"
+                        ? "2학년"
+                        : application.grade === "THIRD"
+                        ? "3학년"
+                        : application.grade === "FOURTH"
+                        ? "4학년"
+                        : application.grade}
+                    </Value>
+                  </InfoItem>
+                  <InfoItem>
+                    <Label>UMC 활동 경험 :</Label>
+                    <Value>
+                      {application.experience === "OB" ? "있음" : "없음"}
+                    </Value>
+                  </InfoItem>
+                </InfoGrid>
+              </Section>
+            </PersonalInfoSection>
+
+            <Divider />
+
+            <Section>
+              <InfoGrid>
+                <InfoItem>
+                  <Label>연락처 :</Label>
+                  <Value>{application.phone}</Value>
+                </InfoItem>
+                <InfoItem>
+                  <Label>디스코드 이메일 :</Label>
+                  <Value>{application.discordEmail}</Value>
+                </InfoItem>
+                <InfoItem>
+                  <Label>노션 이메일 :</Label>
+                  <Value>{application.notionEmail}</Value>
+                </InfoItem>
+                <InfoItem>
+                  <Label>UMC를 알게된 경로 :</Label>
+                  <Value>{application.umcRoute}</Value>
+                </InfoItem>
+                <InfoItem>
+                  <Label>활동 예정인 동아리 :</Label>
+                  <Value>{application.currentClub}</Value>
+                </InfoItem>
+              </InfoGrid>
+            </Section>
+
+            <Divider />
+
+            <Section>
+              <SectionTitle>공통 질문</SectionTitle>
+              {application.answers
+                .filter((answer) => [0, 1, 2, 3, 4].includes(answer.questionId)) // 0번부터 4번까지 공통 질문
+                .map((answer) => (
+                  <AnswerItem key={answer.answerId}>
+                    <Question>{answer.questionText}</Question>
+                    <Answer>{answer.answerText}</Answer>
+                  </AnswerItem>
+                ))}
+            </Section>
+
+            <Divider />
+
+            <Section>
+              <SectionTitle>파트별 질문</SectionTitle>
+              {application.answers
+                .filter((answer) => [5, 6, 7].includes(answer.questionId)) // 5번부터 7번까지 파트별 질문
+                .map((answer) => (
+                  <AnswerItem key={answer.answerId}>
+                    <Question>{answer.questionText}</Question>
+                    <Answer>{answer.answerText}</Answer>
+                  </AnswerItem>
+                ))}
+            </Section>
+          </ApplicationContent>
+        )}
+      </ModalContent>
+    </ModalContainer>
+  );
+};
+
+export default AdminModal;
+
+const PersonalInfoSection = styled.div`
+  display: flex;
+  gap: 12.188rem;
+`;
+
+const ModalContainer = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 3.688rem 7.375rem auto 7.375rem;
+  z-index: 1;
+`;
+
+const ModalContent = styled.div`
+  position: relative;
+  background-color: white;
+  border-radius: 1.25rem;
+  max-width: 67.5rem;
+  height: 50vh;
+  overflow-y: auto;
+`;
+
+const CloseBtn = styled.button`
+  position: absolute;
+  top: 3.188rem;
+  right: 3.781rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+`;
+
+const ApplicationContent = styled.div`
+  padding: 3.688rem 6.375rem;
+`;
+
+const Section = styled.div`
+  margin-bottom: 1.25rem;
+`;
+
+const SectionTitle = styled.h2`
+  font-family: "Pretendard Variable";
+  font-weight: 600;
+  font-size: 1.063rem;
+  line-height: 1.594rem;
+  color: #2b9176;
+  margin-bottom: 1.25rem;
+`;
+
+const InfoGrid = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.938rem;
+`;
+
+const InfoItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+`;
+
+const Label = styled.span`
+  font-family: "Pretendard Variable";
+  font-weight: 600;
+  font-size: 1.063rem;
+  line-height: 1.594rem;
+  color: #000000;
+`;
+
+const Value = styled.span`
+  font-family: "Pretendard Variable";
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.875rem;
+  color: #000000;
+`;
+
+const Divider = styled.div`
+  width: 54.813rem;
+  height: 0;
+  border: 0.094rem solid #e1e9ea;
+  margin: 2.188rem 0;
+`;
+
+const AnswerItem = styled.div`
+  margin-bottom: 2.188rem;
+`;
+
+const Question = styled.div`
+  font-family: "Pretendard Variable";
+  font-weight: 600;
+  font-size: 1.063rem;
+  line-height: 150%;
+  color: #000000;
+  margin-bottom: 0.875rem;
+`;
+
+const Answer = styled.div`
+  font-family: "Pretendard Variable";
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.875rem;
+  color: #000000;
+  white-space: pre-wrap;
+`;

--- a/src/components/admin/AllApplicantsTable.jsx
+++ b/src/components/admin/AllApplicantsTable.jsx
@@ -2,12 +2,15 @@ import styled from "styled-components";
 import axios from "axios";
 import { useState } from "react";
 import ToggleMenu from "./ToggleMenu";
+import AdminModal from "./AdminModal";
 
 const AllApplicantsTable = ({ items }) => {
   const apiUrl = process.env.REACT_APP_API_URL;
 
   const [docPassStatus, setDocPassStatus] = useState({});
   const [finalPassStatus, setFinalPassStatus] = useState({});
+  const [isOpen, setIsOpen] = useState(false); // 모달창 열고 닫기
+  const [application, setApplication] = useState(null);
 
   // 특정 지원자의 지원서 조회
   const handleViewApplication = async (applicantId) => {
@@ -15,13 +18,19 @@ const AllApplicantsTable = ({ items }) => {
       const response = await axios.get(`${apiUrl}/applicant/${applicantId}`);
       if (response.data.isSuccess) {
         console.log("지원서: ", response.data.result);
-        alert("지원서 조회 성공: 임시로 콘솔에서 확인");
+        setApplication(response.data.result);
+        setIsOpen(true); // 모달 상태
       }
     } catch (error) {
       console.error("지원서 조회 에러", error);
       console.log("applicantId", applicantId);
       alert("지원서 조회 중 오류가 발생했습니다. 다시 시도해주세요.");
     }
+  };
+
+  const closeModal = () => {
+    setIsOpen(false);
+    setApplication(null);
   };
 
   // 특정 지원자의 합불 상태 변경
@@ -104,6 +113,8 @@ const AllApplicantsTable = ({ items }) => {
           </TableCell>
         </TableRow>
       ))}
+
+      <AdminModal isOpen={isOpen} closeModal={closeModal} application={application}/>
     </>
   );
 };
@@ -117,7 +128,6 @@ const TableRow = styled.div`
 
   display: grid;
   grid-template-columns: 1fr 2.5fr 1.7fr 1fr 1fr 1fr 0.7fr;
-
 `;
 
 const TableCell = styled.div`

--- a/src/pages/application/ApplicationCommon.jsx
+++ b/src/pages/application/ApplicationCommon.jsx
@@ -114,6 +114,7 @@ const AnswerBig = styled.textarea`
   font-weight: 400;
   line-height: 1.875rem;
   color: #353838;
+  box-sizing: border-box;
 
   &::placeholder {
     color: #818989;
@@ -203,7 +204,7 @@ const DeleteButton = styled.button`
 
 const CountText = styled.span`
   position: absolute;
-  right: -1rem;
+  right: 1.125rem;
   bottom: 1rem;
   color: #818989;
   font-size: 1rem;
@@ -211,7 +212,7 @@ const CountText = styled.span`
 
 const AnswerWrapper = styled.div`
   position: relative;
-  width: 98%;
+  width: 100%;
 `;
 
 const ApplicationCommon = ({

--- a/src/pages/application/ApplicationCommon.jsx
+++ b/src/pages/application/ApplicationCommon.jsx
@@ -211,7 +211,7 @@ const CountText = styled.span`
 
 const AnswerWrapper = styled.div`
   position: relative;
-  width: 100%;
+  width: 98%;
 `;
 
 const ApplicationCommon = ({

--- a/src/pages/application/ApplicationPage.jsx
+++ b/src/pages/application/ApplicationPage.jsx
@@ -202,6 +202,7 @@ const ApplicationPage = () => {
     1: 0,
     2: 0,
     3: 0,
+    6: 0,
   }); // 글자수 카운트
 
   // applicantDTO, file 상태 관리
@@ -261,7 +262,8 @@ const ApplicationPage = () => {
       questionId === 0 ||
       questionId === 1 ||
       questionId === 2 ||
-      questionId === 3
+      questionId === 3 ||
+      questionId === 6
     ) {
       setCharCounts((prev) => ({
         ...prev,
@@ -472,6 +474,7 @@ const ApplicationPage = () => {
       <ApplicationPart
         updateApplicantDTO={updateApplicantDTO}
         handleAnswerChange={handleAnswerChange}
+        charCounts={charCounts}
         refs={questionRefs.current}
       />
 

--- a/src/pages/application/ApplicationPart.jsx
+++ b/src/pages/application/ApplicationPart.jsx
@@ -113,6 +113,7 @@ const AnswerBig = styled.textarea`
   font-weight: 400;
   line-height: 1.875rem; /* 187.5% */
   color: #353838;
+  box-sizing: border-box;
 
   &::placeholder {
     color: #818989;
@@ -147,7 +148,7 @@ const AnswerSmall = styled.textarea`
 
 const CountText = styled.span`
   position: absolute;
-  right: -1rem;
+  right: 1.125rem;
   bottom: 1rem;
   color: #818989;
   font-size: 1rem;
@@ -155,7 +156,7 @@ const CountText = styled.span`
 
 const AnswerWrapper = styled.div`
   position: relative;
-  width: 98%;
+  width: 100%;
 `;
 
 const ApplicationPart = ({ updateApplicantDTO, handleAnswerChange, charCounts, refs }) => {

--- a/src/pages/application/ApplicationPart.jsx
+++ b/src/pages/application/ApplicationPart.jsx
@@ -102,6 +102,7 @@ const Radio = styled.input`
 
 const AnswerBig = styled.textarea`
   font-family: "Pretendard Variable";
+  width: 100%;
   height: 15.063rem;
   padding: 0.938rem 1.125rem;
   background: #fcffff;
@@ -144,7 +145,20 @@ const AnswerSmall = styled.textarea`
   }
 `;
 
-const ApplicationPart = ({ updateApplicantDTO, handleAnswerChange, refs }) => {
+const CountText = styled.span`
+  position: absolute;
+  right: -1rem;
+  bottom: 1rem;
+  color: #818989;
+  font-size: 1rem;
+`;
+
+const AnswerWrapper = styled.div`
+  position: relative;
+  width: 98%;
+`;
+
+const ApplicationPart = ({ updateApplicantDTO, handleAnswerChange, charCounts, refs }) => {
   // 파트 선택 여부
   const [selectPart, setSelectPart] = useState("Plan");
   const handlePartChange = (e) => {
@@ -181,12 +195,16 @@ const ApplicationPart = ({ updateApplicantDTO, handleAnswerChange, refs }) => {
 
       <QuestionWrapper>
         <Question>2. {selectPart} 트랙에 지원하는 이유는 무엇인가요?</Question>
+        <AnswerWrapper>
         <AnswerBig
           type="text"
           placeholder="500자 이하로 얘기해주세요"
           onChange={(e) => handleAnswerChange(6, e)}
           ref={refs[6]}
+          maxLength={500}
         />
+        <CountText>{charCounts[6] || 0}/500자</CountText>
+        </AnswerWrapper>
       </QuestionWrapper>
 
       <QuestionWrapper>

--- a/src/pages/apply/intro/Verification.jsx
+++ b/src/pages/apply/intro/Verification.jsx
@@ -148,7 +148,6 @@ export default Verification;
 const StyledFormGroup = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  width: 44.313rem;
+  max-width: 44.313rem;
   gap: 0.938rem;
 `;


### PR DESCRIPTION
브랜치명이랑 안 맞습니다ㅜㅜ

어드민 페이지의 지원서 상세보기 모달창 구현했습니다.
+
지원서 페이지에서 자잘한 스타일링 수정사항 적용했습니다.
파트별 질문의 textarea에도 500자로 제한하는 글자수 세기 추가했고, 전체 textarea 크기가 다른 placeholder 보다 길어서 `box-sizing: border-box` 추가했습니다.